### PR TITLE
fix: 게시물 API 전체적인 수정

### DIFF
--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -23,7 +23,10 @@ module.exports = async (req, res, next) => {
       throw new Error("토큰이 만료되었습니다.");
     }
 
-    const user = await User.findByPk(decodedToken.id);
+    const user = await User.findOne({
+      where: { userId: decodedToken.id },
+      attributes: { exclude: ["password"] },
+    });
 
     if (!user) {
       const error = new HttpError(


### PR DESCRIPTION
기존에 users 테이블의 PK인 id를 직접적으로 활용했으나 보안 문제가 있다고 생각하여 PK인 id는 내부 로직에서만 사용하고, uuid로 생성한 userId를 외부에 반환할 때 사용하도록 변경했습니다.